### PR TITLE
Updated README.md for react native v0.64.1 and gradle v6.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,9 @@ Fixing AndroidX support and adds support for Web and Desktop.
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
 
 - Add `import com.como.RNTShadowView.ShadowViewPackage;` to the imports at the top of the file
-- Open up `android/app/src/main/java/[...]/MainApplication.java`
 - Add `new ShadowViewPackage()` to the list returned by the `getPackages()` method `packages.add(new ShadowViewPackage());` before 
 
 2. Append the following lines to `android/settings.gradle`:

--- a/README.md
+++ b/README.md
@@ -25,16 +25,17 @@ Fixing AndroidX support and adds support for Web and Desktop.
 1. Open up `android/app/src/main/java/[...]/MainActivity.java`
 
 - Add `import com.como.RNTShadowView.ShadowViewPackage;` to the imports at the top of the file
-- Add `new ShadowViewPackage()` to the list returned by the `getPackages()` method
+- Open up `android/app/src/main/java/[...]/MainApplication.java`
+- Add `new ShadowViewPackage()` to the list returned by the `getPackages()` method `packages.add(new ShadowViewPackage());` before 
 
 2. Append the following lines to `android/settings.gradle`:
    ```
-   include ':@liuyunjs/react-native-simple-shadow-view'
-   project(':@liuyunjs/react-native-simple-shadow-view').projectDir = new File(rootProject.projectDir, 	'../node_modules/@liuyunjs/react-native-simple-shadow-view/android')
+   include ':@liuyunjs:react-native-simple-shadow-view'
+   project(':@liuyunjs:react-native-simple-shadow-view').projectDir = new File(rootProject.projectDir, 	'../node_modules/@liuyunjs/react-native-simple-shadow-view/android')
    ```
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
    ```
-     implementation project(':@liuyunjs/react-native-simple-shadow-view')
+     implementation project(':@liuyunjs:react-native-simple-shadow-view')
    ```
 4. Insert the following lines inside the defaultConfig block in `android/app/build.gradle`:
    ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Fixing AndroidX support and adds support for Web and Desktop.
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
 
 - Add `import com.como.RNTShadowView.ShadowViewPackage;` to the imports at the top of the file
-- Add `new ShadowViewPackage()` to the list returned by the `getPackages()` method `packages.add(new ShadowViewPackage());` before 
+- Add `new ShadowViewPackage()` to the list returned by the `getPackages()` method `packages.add(new ShadowViewPackage());` before `return packages`
 
 2. Append the following lines to `android/settings.gradle`:
    ```


### PR DESCRIPTION
> Adds the given projects to the build. Each path in the supplied list is treated as the path of a project to add to the build. Note that these path are not file paths, but instead specify the location of the new project in the project hierarchy. As such, the supplied paths must use the ':' character as separator (and NOT '/').
https://docs.gradle.org/6.7/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String%5B%5D)